### PR TITLE
Use ISO-8859-2 for romanian subtitles

### DIFF
--- a/base/src/main/java/butter/droid/base/utils/FileUtils.java
+++ b/base/src/main/java/butter/droid/base/utils/FileUtils.java
@@ -50,6 +50,7 @@ public class FileUtils {
         sOverrideMap = new HashMap<>();
         sOverrideMap.put("tr", "ISO-8859-9");
         sOverrideMap.put("sr", "Windows-1250");
+        sOverrideMap.put("ro", "ISO-8859-2");
     }
 
     /**


### PR DESCRIPTION
Seems that UniversalDetector detects romanian subtitles files encoding as WINDOWS-1252 causing issues in displaying some special characters. Romanian subtitles files are usually either UTF-8 (rare) or ISO-8859-2 (very often) so I added romanian into the sOverrideMap to use ISO-8859-2 when the subtitle is not in UTF-8 encoding.