### PR TITLE
Subtitle provider fix for media providers.

### DIFF
--- a/base/src/main/java/butter/droid/base/BaseApplicationModule.java
+++ b/base/src/main/java/butter/droid/base/BaseApplicationModule.java
@@ -24,6 +24,7 @@ import javax.inject.Singleton;
 import butter.droid.base.data.DataModule;
 import butter.droid.base.manager.ManagerModule;
 import butter.droid.base.providers.ProviderModule;
+import butter.droid.base.providers.subs.open.OpenSubsModule;
 import dagger.Module;
 import dagger.Provides;
 
@@ -31,7 +32,8 @@ import dagger.Provides;
         includes = {
                 DataModule.class,
                 ManagerModule.class,
-                ProviderModule.class
+                ProviderModule.class,
+                OpenSubsModule.class
         }
 )
 public class BaseApplicationModule {

--- a/base/src/main/java/butter/droid/base/providers/ProviderModule.java
+++ b/base/src/main/java/butter/droid/base/providers/ProviderModule.java
@@ -26,10 +26,12 @@ import javax.inject.Singleton;
 import butter.droid.base.providers.media.AnimeProvider;
 import butter.droid.base.providers.media.MoviesProvider;
 import butter.droid.base.providers.media.TVProvider;
-import butter.droid.base.providers.subs.SubsProvider;
+import butter.droid.base.providers.meta.TraktProvider;
+import butter.droid.base.providers.subs.open.OpenSubsProvider;
 import butter.droid.base.providers.subs.ysubs.YSubsProvider;
 import dagger.Module;
 import dagger.Provides;
+import de.timroes.axmlrpc.XMLRPCClient;
 import okhttp3.OkHttpClient;
 
 @Module
@@ -37,29 +39,41 @@ public class ProviderModule {
 
     @Provides
     @Singleton
-    public SubsProvider provideSubsProvider(Context context, OkHttpClient client, ObjectMapper mapper) {
+    public YSubsProvider provideYSubsProvider(Context context, OkHttpClient client, ObjectMapper mapper) {
         return new YSubsProvider(context, client, mapper);
     }
 
     @Provides
     @Singleton
+    public OpenSubsProvider provideOpenSubsProvider(Context context, OkHttpClient client, ObjectMapper mapper, XMLRPCClient xmlrpcClient) {
+        return new OpenSubsProvider(context, client, mapper, xmlrpcClient);
+    }
+
+    @Provides
+    @Singleton
+    public TraktProvider provideTraktProvider(OkHttpClient client, ObjectMapper mapper) {
+        return new TraktProvider(client, mapper);
+    }
+
+    @Provides
+    @Singleton
     public MoviesProvider provideMoviesProvider(OkHttpClient client, ObjectMapper mapper,
-                                                SubsProvider subsProvider) {
-        return new MoviesProvider(client, mapper, subsProvider);
+                                                YSubsProvider ySubsProvider) {
+        return new MoviesProvider(client, mapper, ySubsProvider);
     }
 
     @Provides
     @Singleton
     public TVProvider provideTVProvider(OkHttpClient client, ObjectMapper mapper,
-                                        SubsProvider subsProvider) {
-        return new TVProvider(client, mapper, subsProvider);
+                                        OpenSubsProvider subsProvider, TraktProvider traktProvider) {
+        return new TVProvider(client, mapper, subsProvider, traktProvider);
     }
 
     @Provides
     @Singleton
     public AnimeProvider provideAnimeProvider(OkHttpClient client, ObjectMapper mapper,
-                                              SubsProvider subsProvider) {
-        return new AnimeProvider(client, mapper, subsProvider);
+                                              YSubsProvider ySubsProvider) {
+        return new AnimeProvider(client, mapper, ySubsProvider);
     }
 
 }

--- a/base/src/main/java/butter/droid/base/providers/media/TVProvider.java
+++ b/base/src/main/java/butter/droid/base/providers/media/TVProvider.java
@@ -42,10 +42,9 @@ public class TVProvider extends MediaProvider {
 
     private MetaProvider metaProvider;
 
-
-    public TVProvider(OkHttpClient client, ObjectMapper mapper, @Nullable SubsProvider subsProvider) {
+    public TVProvider(OkHttpClient client, ObjectMapper mapper, @Nullable SubsProvider subsProvider, MetaProvider metaProvider) {
         super(client, mapper, subsProvider, BuildConfig.TV_URLS, "shows/", "show/", 0);
-        metaProvider = new TraktProvider(client, mapper);
+        this.metaProvider = new TraktProvider(client, mapper);
     }
 
     @Override


### PR DESCRIPTION
We were using the same subtitles provider for all media.
Changed TVProvider constructor to receive the meta provider.