### PR TITLE
Fix for #71

### DIFF
--- a/base/src/main/java/butter/droid/base/utils/StorageUtils.java
+++ b/base/src/main/java/butter/droid/base/utils/StorageUtils.java
@@ -211,6 +211,14 @@ public class StorageUtils extends Compatibility {
         return externalCacheDir;
     }
 
+    public static String getInternalSdCardPath(){
+        return System.getenv("EXTERNAL_STORAGE");
+    }
+
+    public static String getExternalSdCardPath(){
+        return System.getenv("SECONDARY_STORAGE");
+    }
+
     /**
      * Format size in string form
      *

--- a/mobile/src/main/java/butter/droid/activities/MainActivity.java
+++ b/mobile/src/main/java/butter/droid/activities/MainActivity.java
@@ -38,6 +38,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.EditText;
+import android.widget.Toast;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -108,8 +109,8 @@ public class MainActivity extends ButterBaseActivity implements ProviderManager.
             startActivity(new Intent(this, TermsActivity.class));
         }
 
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, PERMISSIONS_REQUEST);
+        if(!isFullAccessStorageAllowed()){
+            ActivityCompat.requestPermissions(this,new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, PERMISSIONS_REQUEST);
         }
 
         String action = getIntent().getAction();
@@ -379,11 +380,22 @@ public class MainActivity extends ButterBaseActivity implements ProviderManager.
         builder.show();
     }
 
+    private boolean isFullAccessStorageAllowed() {
+        int read = ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE);
+        int write = ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+        if (read == PackageManager.PERMISSION_GRANTED && write == PackageManager.PERMISSION_GRANTED)
+            return true;
+
+        return false;
+    }
+
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
         switch (requestCode) {
             case PERMISSIONS_REQUEST: {
                 if (grantResults.length < 1 || grantResults[0] == PackageManager.PERMISSION_DENIED) {
+                    Toast.makeText(this,"Permissions granted, now you can read and write the storage",Toast.LENGTH_LONG).show();
                     finish();
                 }
             }

--- a/mobile/src/main/java/butter/droid/activities/PreferencesActivity.java
+++ b/mobile/src/main/java/butter/droid/activities/PreferencesActivity.java
@@ -52,6 +52,7 @@ import butter.droid.base.fragments.dialog.StringArraySelectorDialogFragment;
 import butter.droid.base.manager.updater.ButterUpdateManager;
 import butter.droid.base.utils.PrefUtils;
 import butter.droid.base.utils.ResourceUtils;
+import butter.droid.base.utils.StorageUtils;
 import butter.droid.fragments.dialog.ColorPickerDialogFragment;
 import butter.droid.fragments.dialog.SeekBarDialogFragment;
 import butter.droid.utils.ToolbarUtils;
@@ -194,6 +195,9 @@ public class PreferencesActivity extends ButterBaseActivity
                         onSelectionListener.onSelection(0, null);
                     } else {
                         DirectoryChooserConfig config = DirectoryChooserConfig.builder()
+                                .initialDirectory(StorageUtils.getInternalSdCardPath())
+                                .allowReadOnlyDirectory(true)
+                                .allowNewDirectoryNameModification(true)
                                 .newDirectoryName(getString(R.string.app_name))
                                 .build();
 


### PR DESCRIPTION
- Check and request for write and read perms for external storage on the main activity.

- Get the human readable path for internal and external sd cards on storage utils.

- Initial directory point  to sdcard when choosing a custom cache directory.

- Allowed read only dirs list, and change for new directory name on directory chooser.