### PR TITLE
Fixed crash if subtitles are not available

### DIFF
--- a/base/src/main/java/butter/droid/base/providers/subs/open/OpenSubsProvider.java
+++ b/base/src/main/java/butter/droid/base/providers/subs/open/OpenSubsProvider.java
@@ -19,6 +19,7 @@ package butter.droid.base.providers.subs.open;
 
 import android.content.Context;
 
+import com.amazon.whisperlink.util.StringUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
@@ -66,7 +67,7 @@ public class OpenSubsProvider extends SubsProvider {
                 final String episodeStr = Integer.toString(episode.episode);
                 final String seasonStr = Integer.toString(episode.season);
 
-                if (!token.isEmpty()) {
+                if (!StringUtil.isEmpty(token)) {
                     search(episode, token, new XMLRPCCallback() {
                         @Override
                         public void onResponse(long id, Object result) {


### PR DESCRIPTION
The crash can be reproduced if you open Simpsons S28E01. Looks like `token` is not set.

I'm not sure if I should use this `StringUtil` class, happy to add the function to Butter's `StringUtils` instead.