### PR TITLE
Fix default order for TV provider

### DIFF
--- a/provider/media/tv/src/main/java/pct/droid/provider/tv/TvProvider.java
+++ b/provider/media/tv/src/main/java/pct/droid/provider/tv/TvProvider.java
@@ -135,7 +135,7 @@ public class TvProvider extends AbsMediaProvider {
             page = 1;
         }
 
-        return tvService.fetchShows(page, query, genre, sorter, 1, null, ITEMS_PER_PAGE)
+        return tvService.fetchShows(page, query, genre, sorter, -1, null, ITEMS_PER_PAGE)
                 .flatMapObservable(Observable::fromArray)
                 .map(this::mapApiShow)
                 .cast(Media.class)


### PR DESCRIPTION
The order was reversed, showing exactly the opposite of what a user would like to see