### PR TITLE
Add a favourites tab

### DIFF
--- a/base/src/main/java/butter/droid/base/Constants.java
+++ b/base/src/main/java/butter/droid/base/Constants.java
@@ -21,6 +21,7 @@ public class Constants {
 
     public static Boolean DEBUG_ENABLED = BuildConfig.DEBUG; // will be set to true for debug builds and false for release builds
     public static final String PREFS_FILE = "PCT_Prefs";
+    public static final String PREFS_FILE_FAVOURITES = "PCT_Favourites";
     public static final Integer SERVER_PORT = 55723;
     public static final String GIT_URL = "https://github.com/popcorn-official/popcorn-android";
     public static final String BUTTER_URL = "https://popcorntime.sh/";

--- a/base/src/main/java/butter/droid/base/providers/media/models/Media.java
+++ b/base/src/main/java/butter/droid/base/providers/media/models/Media.java
@@ -24,8 +24,13 @@ import android.os.Parcelable;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import butter.droid.base.manager.provider.ProviderManager;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use=JsonTypeInfo.Id.CLASS, include=JsonTypeInfo.As.PROPERTY, property="@class")
 public abstract class Media implements Parcelable {
 
     public String videoId;

--- a/base/src/main/java/butter/droid/base/providers/media/models/Show.java
+++ b/base/src/main/java/butter/droid/base/providers/media/models/Show.java
@@ -47,6 +47,7 @@ public class Show extends Media implements Parcelable {
     public String synopsis = "No synopsis available";
     public Integer seasons = 0;
     public LinkedList<Episode> episodes = new LinkedList<>();
+    public Boolean isAnime = false;
     private String certification = "n/a";
 
     public Show() {

--- a/base/src/main/java/butter/droid/base/providers/media/response/AnimeDetailsReponse.java
+++ b/base/src/main/java/butter/droid/base/providers/media/response/AnimeDetailsReponse.java
@@ -33,6 +33,7 @@ public class AnimeDetailsReponse extends DetailsResponse<AnimeDetails> {
                  */
             if (item.getType().equalsIgnoreCase("show")) {
                 Show show = new Show();
+                show.isAnime = true;
                 show.seasons = item.getNumSeasons();
                 show.runtime = item.getRuntime();
                 show.synopsis = item.getSynopsis();

--- a/base/src/main/java/butter/droid/base/providers/media/response/AnimeResponse.java
+++ b/base/src/main/java/butter/droid/base/providers/media/response/AnimeResponse.java
@@ -30,6 +30,7 @@ public class AnimeResponse extends Response<Anime> {
             } else if (item.getType().equalsIgnoreCase("show")) {
                 Show show = new Show();
 
+                show.isAnime = true;
                 show.title = item.getTitle();
                 show.videoId = item.getId();
                 show.seasons = item.getNumSeasons();

--- a/base/src/main/java/butter/droid/base/utils/FavouriteUtils.java
+++ b/base/src/main/java/butter/droid/base/utils/FavouriteUtils.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of Butter.
+ *
+ * Butter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Butter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Butter. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package butter.droid.base.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import butter.droid.base.Constants;
+import butter.droid.base.providers.media.models.Media;
+
+public class FavouriteUtils {
+    private static final String TAG = "FavouriteUtils";
+
+    public static ArrayList<Media> getFavourites(Context context, Class provider) {
+        Map<String, Media> map = getFavouriteMap(context, provider);
+        return new ArrayList<Media>(map.values());
+    }
+
+    public static Boolean isFavourite(Context context, Class provider, Media media) {
+        return isFavourite(context, provider, media.videoId);
+    }
+
+    public static Boolean isFavourite(Context context, Class provider, String videoId) {
+        Set<String> ids = getFavouriteMap(context, provider).keySet();
+        return ids.contains(videoId);
+    }
+
+    public static void addFavourite(Context context, Class provider, Media media) {
+        Map<String, Media> map = getFavouriteMap(context, provider);
+        map.put(media.videoId, media);
+        setFavouriteMap(context, provider, map);
+    }
+
+    public static void removeFavourite(Context context, Class provider, Media media) {
+        removeFavourite(context, provider, media.videoId);
+    }
+
+    public static void removeFavourite(Context context, Class provider, String videoId) {
+        Map<String, Media> map = getFavouriteMap(context, provider);
+        map.remove(videoId);
+        setFavouriteMap(context, provider, map);
+    }
+
+    public static Map<String, Media> getFavouriteMap(Context context, Class provider) {
+        SharedPreferences prefs = getPrefs(context);
+        String serialized = prefs.getString(provider.getName(), "{}");
+
+        ObjectMapper mapper = new ObjectMapper();
+        TypeReference<HashMap<String,Media>> typeRef = new TypeReference<HashMap<String,Media>>() {};
+        try {
+            return mapper.readValue(serialized, typeRef);
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to deserialize favourites", e);
+            return new HashMap<String,Media>();
+        }
+    }
+
+    public static void setFavouriteMap(Context context, Class provider, Map<String, Media> map) {
+        ObjectMapper mapper = new ObjectMapper();
+        TypeReference<HashMap<String,Media>> typeRef = new TypeReference<HashMap<String,Media>>() {};
+        String serialized;
+        try {
+            serialized = mapper.writerFor(typeRef).writeValueAsString(map);
+        } catch (JsonProcessingException e) {
+            Log.e(TAG, "Failed to serialize favourites", e);
+            return;
+        }
+
+        SharedPreferences prefs = getPrefs(context);
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putString(provider.getName(), serialized);
+        editor.commit();
+    }
+
+    public static SharedPreferences getPrefs(Context context) {
+        return context.getSharedPreferences(Constants.PREFS_FILE_FAVOURITES, Context.MODE_PRIVATE);
+    }
+}

--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="search">Search</string>
     <string name="searching">Searching…</string>
     <string name="no_data_found">No data found</string>
+    <string name="no_favourites">No favourites</string>
     <string name="title_shows">Shows</string>
     <string name="title_movies">Movies</string>
     <string name="title_anime">Anime</string>
@@ -120,6 +121,8 @@
     <string name="minutes">min</string>
     <string name="read_more">Read more</string>
     <string name="watch_trailer">Watch trailer</string>
+    <string name="add_to_favourites">Add to favourites</string>
+    <string name="remove_from_favourites">Remove from favourites</string>
     <string name="no_subs">No subtitles</string>
     <string name="no_subs_available">No subtitles available</string>
     <string name="quality">Quality</string>
@@ -222,6 +225,7 @@
     <string name="genre_yuri">Yuri</string>
 
     <!-- Possible tabs -->
+    <string name="favourites">FAVOURITES</string>
     <string name="popular">POPULAR</string>
     <string name="top_rated">TOP RATED</string>
     <string name="release_date">RELEASE DATE</string>

--- a/mobile/src/main/java/butter/droid/adapters/MediaPagerAdapter.java
+++ b/mobile/src/main/java/butter/droid/adapters/MediaPagerAdapter.java
@@ -62,7 +62,7 @@ public class MediaPagerAdapter extends FragmentStatePagerAdapter {
 
     @Override
     public int getCount() {
-        return mTabs.size() + mHasGenreTabs;
+        return mTabs.size() + mHasGenreTabs + 1;
     }
 
     @Override
@@ -70,7 +70,12 @@ public class MediaPagerAdapter extends FragmentStatePagerAdapter {
         if (mHasGenreTabs > 0 && position == 0) {
             return ButterApplication.getAppContext().getString(R.string.genres).toUpperCase(LocaleUtils.getCurrent());
         }
-        position -= mHasGenreTabs;
+
+        if (position == 1) {
+            return ButterApplication.getAppContext().getString(R.string.favourites).toUpperCase(LocaleUtils.getCurrent());
+        }
+
+        position -= mHasGenreTabs + 1;
         return mTabs.get(position).getLabel().toUpperCase(LocaleUtils.getCurrent());
     }
 
@@ -83,7 +88,11 @@ public class MediaPagerAdapter extends FragmentStatePagerAdapter {
             return mGenreFragment;
         }
 
-        position -= mHasGenreTabs;
+        if (position == 1) {
+            return MediaListFragment.newInstance(MediaListFragment.Mode.FAVOURITES);
+        }
+
+        position -= mHasGenreTabs + 1;
         return MediaListFragment.newInstance(MediaListFragment.Mode.NORMAL, mTabs.get(position).getFilter(), mTabs.get(position).getOrder(), mGenre);
     }
 

--- a/mobile/src/main/java/butter/droid/fragments/MediaListFragment.java
+++ b/mobile/src/main/java/butter/droid/fragments/MediaListFragment.java
@@ -18,6 +18,7 @@
 package butter.droid.fragments;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Bundle;
@@ -53,6 +54,7 @@ import butter.droid.base.utils.LocaleUtils;
 import butter.droid.base.utils.NetworkUtils;
 import butter.droid.base.utils.PrefUtils;
 import butter.droid.base.utils.ThreadUtils;
+import butter.droid.base.utils.FavouriteUtils;
 import butter.droid.fragments.dialog.LoadingDetailDialogFragment;
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -211,6 +213,16 @@ public class MediaListFragment extends Fragment implements LoadingDetailDialogFr
 
         }
     };
+    private SharedPreferences.OnSharedPreferenceChangeListener mOnSharedPrefChangeListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
+        @Override
+        public void onSharedPreferenceChanged(SharedPreferences prefs, String key) {
+            loadFavourites();
+        }
+    };
+
+    public static MediaListFragment newInstance(Mode mode) {
+        return newInstance(mode, null, null, null);
+    }
 
     public static MediaListFragment newInstance(Mode mode, MediaProvider.Filters.Sort filter, MediaProvider.Filters.Order defOrder) {
         return newInstance(mode, filter, defOrder, null);
@@ -248,11 +260,18 @@ public class MediaListFragment extends Fragment implements LoadingDetailDialogFr
         super.onViewCreated(view, savedInstanceState);
 
         mRecyclerView.setHasFixedSize(true);
-        mRecyclerView.addOnScrollListener(mScrollListener);
+        if (mMode != Mode.FAVOURITES) {
+            mRecyclerView.addOnScrollListener(mScrollListener);
+        }
         //adapter should only ever be created once on fragment initialise.
         mAdapter = new MediaGridAdapter(mContext, mItems, mColumns);
         mAdapter.setOnItemClickListener(mOnItemClickListener);
         mRecyclerView.setAdapter(mAdapter);
+
+        if (mMode == Mode.FAVOURITES) {
+            SharedPreferences prefs = FavouriteUtils.getPrefs(mContext);
+            prefs.registerOnSharedPreferenceChangeListener(mOnSharedPrefChangeListener);
+        }
     }
 
     @Override
@@ -274,6 +293,11 @@ public class MediaListFragment extends Fragment implements LoadingDetailDialogFr
             providerManager.getCurrentMediaProvider()
                     .getList(new MediaProvider.Filters(mFilters), mCallback);
         }
+    }
+
+    public void loadFavourites() {
+        mItems = FavouriteUtils.getFavourites(mContext, providerManager.getCurrentMediaProvider().getClass());
+        mAdapter.setItems(mItems);
     }
 
     @Override
@@ -311,6 +335,9 @@ public class MediaListFragment extends Fragment implements LoadingDetailDialogFr
         super.onActivityCreated(savedInstanceState);
         if (mMode == Mode.SEARCH) {
             mEmptyView.setText(getString(R.string.no_search_results));
+        } else if (mMode == Mode.FAVOURITES) {
+            mEmptyView.setText(getString(R.string.no_favourites));
+            loadFavourites();
         } else if (mAdapter.getItemCount() == 0) { //don't load initial data in search mode
             setState(State.LOADING);
             providerManager.getCurrentMediaProvider().getList(new MediaProvider.Filters(mFilters), mCallback);/* fetch new items */
@@ -431,7 +458,7 @@ public class MediaListFragment extends Fragment implements LoadingDetailDialogFr
     }
 
     public enum Mode {
-        NORMAL, SEARCH
+        NORMAL, SEARCH, FAVOURITES
     }
 
     private enum State {

--- a/mobile/src/main/java/butter/droid/fragments/MovieDetailFragment.java
+++ b/mobile/src/main/java/butter/droid/fragments/MovieDetailFragment.java
@@ -33,6 +33,7 @@ import butter.droid.base.content.preferences.DefaultQuality;
 import butter.droid.base.content.preferences.Prefs;
 import butter.droid.base.manager.provider.ProviderManager;
 import butter.droid.base.manager.youtube.YouTubeManager;
+import butter.droid.base.providers.media.MoviesProvider;
 import butter.droid.base.providers.media.models.Movie;
 import butter.droid.base.providers.subs.SubsProvider;
 import butter.droid.base.torrent.Magnet;
@@ -45,6 +46,7 @@ import butter.droid.base.utils.SortUtils;
 import butter.droid.base.utils.StringUtils;
 import butter.droid.base.utils.ThreadUtils;
 import butter.droid.base.utils.VersionUtils;
+import butter.droid.base.utils.FavouriteUtils;
 import butter.droid.fragments.base.BaseDetailFragment;
 import butter.droid.fragments.dialog.SynopsisDialogFragment;
 import butter.droid.widget.OptionSelector;
@@ -78,6 +80,8 @@ public class MovieDetailFragment extends BaseDetailFragment {
     Button mReadMore;
     @BindView(R.id.watch_trailer)
     Button mWatchTrailer;
+    @BindView(R.id.toggle_favourite)
+    Button mToggleFavourite;
     @BindView(R.id.magnet)
     ImageButton mOpenMagnet;
     @BindView(R.id.rating)
@@ -167,6 +171,10 @@ public class MovieDetailFragment extends BaseDetailFragment {
             }
 
             mWatchTrailer.setVisibility(sMovie.trailer == null || sMovie.trailer.isEmpty() ? View.GONE : View.VISIBLE);
+
+            Context context = MobileButterApplication.getAppContext();
+            mToggleFavourite.setText(FavouriteUtils.isFavourite(context, MoviesProvider.class, sMovie) ?
+                R.string.remove_from_favourites : R.string.add_to_favourites);
 
             mSubtitles.setFragmentManager(getFragmentManager());
             mQuality.setFragmentManager(getFragmentManager());
@@ -335,6 +343,18 @@ public class MovieDetailFragment extends BaseDetailFragment {
             VideoPlayerActivity.startActivity(mActivity, new StreamInfo(sMovie, null, null, null, null, sMovie.trailer));
         } else {
             TrailerPlayerActivity.startActivity(mActivity, sMovie.trailer, sMovie);
+        }
+    }
+
+    @OnClick(R.id.toggle_favourite)
+    public void toggleFavourite(View v) {
+        Context context = MobileButterApplication.getAppContext();
+        if (FavouriteUtils.isFavourite(context, MoviesProvider.class, sMovie)) {
+            FavouriteUtils.removeFavourite(context, MoviesProvider.class, sMovie);
+            mToggleFavourite.setText(R.string.add_to_favourites);
+        } else {
+            FavouriteUtils.addFavourite(context, MoviesProvider.class, sMovie);
+            mToggleFavourite.setText(R.string.remove_from_favourites);
         }
     }
 

--- a/mobile/src/main/java/butter/droid/fragments/ShowDetailAboutFragment.java
+++ b/mobile/src/main/java/butter/droid/fragments/ShowDetailAboutFragment.java
@@ -1,6 +1,7 @@
 package butter.droid.fragments;
 
 import android.annotation.TargetApi;
+import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -14,10 +15,15 @@ import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.RatingBar;
 import android.widget.TextView;
+import android.util.Log;
 
 import butter.droid.R;
+import butter.droid.MobileButterApplication;
+import butter.droid.base.providers.media.AnimeProvider;
+import butter.droid.base.providers.media.TVProvider;
 import butter.droid.base.providers.media.models.Show;
 import butter.droid.base.utils.VersionUtils;
+import butter.droid.base.utils.FavouriteUtils;
 import butter.droid.fragments.base.BaseDetailFragment;
 import butter.droid.fragments.dialog.SynopsisDialogFragment;
 import butterknife.BindView;
@@ -38,6 +44,8 @@ public class ShowDetailAboutFragment extends BaseDetailFragment {
     RatingBar mRating;
     @BindView(R.id.read_more)
     Button mReadMore;
+    @BindView(R.id.toggle_favourite)
+    Button mToggleFavourite;
     @BindView(R.id.info_buttons)
     LinearLayout mInfoButtons;
     @BindView(R.id.magnet)
@@ -112,12 +120,17 @@ public class ShowDetailAboutFragment extends BaseDetailFragment {
                             ellipsized = true;
                         }
                     }
-                    mInfoButtons.setVisibility(ellipsized ? View.VISIBLE : View.GONE);
+                    mReadMore.setVisibility(ellipsized ? View.VISIBLE : View.GONE);
                 }
             });
         } else {
-            mInfoButtons.setVisibility(View.GONE);
+            mReadMore.setVisibility(View.GONE);
         }
+
+        Context context = MobileButterApplication.getAppContext();
+        Class provider = sShow.isAnime ? AnimeProvider.class : TVProvider.class;
+        mToggleFavourite.setText(FavouriteUtils.isFavourite(context, provider, sShow) ?
+            R.string.remove_from_favourites : R.string.add_to_favourites);
 
         mOpenMagnet.setVisibility(View.GONE);
 
@@ -133,6 +146,19 @@ public class ShowDetailAboutFragment extends BaseDetailFragment {
         b.putString("text", sShow.synopsis);
         synopsisDialogFragment.setArguments(b);
         synopsisDialogFragment.show(getFragmentManager(), "overlay_fragment");
+    }
+
+    @OnClick(R.id.toggle_favourite)
+    public void toggleFavourite(View v) {
+        Context context = MobileButterApplication.getAppContext();
+        Class provider = sShow.isAnime ? AnimeProvider.class : TVProvider.class;
+        if (FavouriteUtils.isFavourite(context, provider, sShow)) {
+            FavouriteUtils.removeFavourite(context, provider, sShow);
+            mToggleFavourite.setText(R.string.add_to_favourites);
+        } else {
+            FavouriteUtils.addFavourite(context, provider, sShow);
+            mToggleFavourite.setText(R.string.remove_from_favourites);
+        }
     }
 
 }

--- a/mobile/src/main/res/layout-w800dp/fragment_showdetail.xml
+++ b/mobile/src/main/res/layout-w800dp/fragment_showdetail.xml
@@ -109,6 +109,12 @@
                     android:text="@string/read_more"
                     app:typeface="roboto_medium"  />
 
+                <com.devspark.robototextview.widget.RobotoButton
+                    style="@style/Theme.Butter.DetailButton"
+                    android:id="@+id/toggle_favourite"
+                    android:text="@string/add_to_favourites"
+                    app:typeface="roboto_medium"  />
+
             </LinearLayout>
         </RelativeLayout>
     </LinearLayout>

--- a/mobile/src/main/res/layout/fragment_detail_about.xml
+++ b/mobile/src/main/res/layout/fragment_detail_about.xml
@@ -142,6 +142,12 @@
             android:id="@+id/watch_trailer"
             android:text="@string/watch_trailer"
             app:typeface="roboto_medium"  />
+
+        <com.devspark.robototextview.widget.RobotoButton
+            style="@style/Theme.Butter.DetailButton"
+            android:id="@+id/toggle_favourite"
+            android:text="@string/add_to_favourites"
+            app:typeface="roboto_medium"  />
     </LinearLayout>
 
 </RelativeLayout>


### PR DESCRIPTION
This PR adds a favourites tab for all provider types. Favourites are stored in one SharedPreference per provider, as serialized Media objects.

Screenshots:

![](https://i.imgur.com/b6i0feml.jpg) ![](https://i.imgur.com/VHeGHh7l.jpg) ![](https://i.imgur.com/mmta9Tnl.png)