### PR TITLE
Show trending movies in recommendation channel

### DIFF
--- a/tv/src/main/java/butter/droid/tv/service/RecommendationService.java
+++ b/tv/src/main/java/butter/droid/tv/service/RecommendationService.java
@@ -82,7 +82,7 @@ public class RecommendationService extends IntentService {
 
         MediaProvider.Filters movieFilter = new MediaProvider.Filters();
         movieFilter.setOrder(MediaProvider.Filters.Order.DESC);
-        movieFilter.setSort(MediaProvider.Filters.Sort.POPULARITY);
+        movieFilter.setSort(MediaProvider.Filters.Sort.TRENDING);
 
         /*
         Disabled, since no shows provider

--- a/tv/src/main/java/butter/droid/tv/service/RecommendationService.java
+++ b/tv/src/main/java/butter/droid/tv/service/RecommendationService.java
@@ -46,8 +46,8 @@ import timber.log.Timber;
 
 public class RecommendationService extends IntentService {
 
-    private static final int MAX_MOVIE_RECOMMENDATIONS = 3;
-    private static final int MAX_SHOW_RECOMMENDATIONS = 3;
+    private static final int MAX_MOVIE_RECOMMENDATIONS = 10;
+    private static final int MAX_SHOW_RECOMMENDATIONS = 10;
     @Inject
     ProviderManager providerManager;
     private ArrayList<Media> mMovies = new ArrayList<>();


### PR DESCRIPTION
The Popular movies filter is pretty stale. It hasn't changed in a year. The trending filter should be used instead to show the latest popular entries.