### PR TITLE
Fix stream loading reporting

### DIFF
--- a/base/src/main/java/butter/droid/base/utils/StorageUtils.java
+++ b/base/src/main/java/butter/droid/base/utils/StorageUtils.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Scanner;
 
@@ -223,15 +224,15 @@ public class StorageUtils extends Compatibility {
      * Format size in string form
      *
      * @param size Size in bytes
-     * @return Size in stinrg format with suffix
+     * @return Size in string format with suffix
      */
     public static String formatSize(int size) {
         String suffix = null;
 
-        if (size >= 1024) {
-            suffix = "KB";
-            size /= 1024;
-            if (size >= 1024) {
+        if (size >= 1000) {
+            suffix = "kB";
+            size /= 1000;
+            if (size >= 1000) {
                 suffix = "MB";
                 size /= 1024;
             }
@@ -245,7 +246,34 @@ public class StorageUtils extends Compatibility {
             commaOffset -= 3;
         }
 
-        if (suffix != null) resultBuffer.append(suffix);
+        if (suffix != null) resultBuffer.append(" ").append(suffix);
         return resultBuffer.toString();
+    }
+
+    /**
+     * Formats information rate as a string with appropriate units
+     * @param rate Information rate in bytes per second
+     * @return Byte rate with units as a string
+     */
+    public static String formatRate(int rate) {
+        float speed = (float)rate;
+        if (speed < 1000) {
+            return String.format(Locale.getDefault(), "%.0f B/s", speed);
+        }
+
+        speed /= 1000;
+        if (speed < 100) {
+            return String.format(Locale.getDefault(), "%.1f kB/s", speed);
+        }
+        if (speed < 1000) {
+            return String.format(Locale.getDefault(), "%.0f kB/s", speed);
+        }
+
+        speed /= 1000;
+        if (speed < 100) {
+            return String.format(Locale.getDefault(), "%.1f MB/s", speed);
+        } else {
+            return String.format(Locale.getDefault(), "%.0f MB/s", speed);
+        }
     }
 }

--- a/base/src/main/res/values-ar/strings.xml
+++ b/base/src/main/res/values-ar/strings.xml
@@ -199,7 +199,7 @@
   <string name="starting_buffering">بدأ التخزين المؤقت</string>
   <string name="streaming_started">بدأ العرض</string>
   <string name="waiting_for_subtitles">في إنتظار الترجمة</string>
-  <string name="seeds">موزع</string>
+  <string name="seeds">%1$d موزع</string>
   <string name="start_external">إبدأ بمشغل وسائط خارجي</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">تقديم سريع</string>

--- a/base/src/main/res/values-bg/strings.xml
+++ b/base/src/main/res/values-bg/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Започване на буферирането </string>
   <string name="streaming_started">Стриймването започна</string>
   <string name="waiting_for_subtitles">Изчакване за субтитри</string>
-  <string name="seeds">сийдъри</string>
+  <string name="seeds">%1$d сийдъри</string>
   <string name="start_external">Стартирай външният плейър</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Превърти напред</string>

--- a/base/src/main/res/values-bn/strings.xml
+++ b/base/src/main/res/values-bn/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">বাফারিং শুরু হচ্ছে</string>
   <string name="streaming_started">স্ট্রিমিং শুরু হয়েছে</string>
   <string name="waiting_for_subtitles">সাবটাইটেলের জন্য অপেক্ষারত</string>
-  <string name="seeds">সিড</string>
+  <string name="seeds">%1$d সিড</string>
   <string name="start_external">বহিঃস্থ প্লেয়ার শুরু করুন</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">দ্রুত সামনে</string>

--- a/base/src/main/res/values-bs/strings.xml
+++ b/base/src/main/res/values-bs/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Pokretanje međuspremanja</string>
   <string name="streaming_started">Streamanje pokrenuto</string>
   <string name="waiting_for_subtitles">Čekanje podnaslova</string>
-  <string name="seeds">djelitelja</string>
+  <string name="seeds">%1$d djelitelja</string>
   <string name="start_external">Pokreni vanjski reproduktor</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Premotavanje unaprijed</string>

--- a/base/src/main/res/values-ca/strings.xml
+++ b/base/src/main/res/values-ca/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">S\'està iniciant la precàrrega</string>
   <string name="streaming_started">S\'ha iniciat la transmissió</string>
   <string name="waiting_for_subtitles">S\'estan esperant els subtítols</string>
-  <string name="seeds">llavors</string>
+  <string name="seeds">%1$d llavors</string>
   <string name="start_external">Inicia un reproductor extern</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Avança</string>

--- a/base/src/main/res/values-cs/strings.xml
+++ b/base/src/main/res/values-cs/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Spouštění načítání</string>
   <string name="streaming_started">Vysílání započato</string>
   <string name="waiting_for_subtitles">Čekání na titulky</string>
-  <string name="seeds">seedů:</string>
+  <string name="seeds">%1$d seedů:</string>
   <string name="start_external">Zapnout externí přehrávač</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Posunout dopředu</string>

--- a/base/src/main/res/values-da/strings.xml
+++ b/base/src/main/res/values-da/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Gemmer i bufferen</string>
   <string name="streaming_started">Streaming startet</string>
   <string name="waiting_for_subtitles">Venter på undertekster</string>
-  <string name="seeds">seeds</string>
+  <string name="seeds">%1$d seeds</string>
   <string name="start_external">Start ekstern afspiller</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Spol fremad</string>

--- a/base/src/main/res/values-de/strings.xml
+++ b/base/src/main/res/values-de/strings.xml
@@ -209,7 +209,7 @@
   <string name="starting_buffering">Pufferung wird gestartet</string>
   <string name="streaming_started">Streaming gestartet</string>
   <string name="waiting_for_subtitles">Auf Untertitel wird gewartet</string>
-  <string name="seeds">Seeds</string>
+  <string name="seeds">%1$d Seeds</string>
   <string name="start_external">Externen Abspieler starten</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Schnellvorlauf</string>

--- a/base/src/main/res/values-el/strings.xml
+++ b/base/src/main/res/values-el/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Εκκίνηση φόρτωσης</string>
   <string name="streaming_started">Άρχισε η ροή δεδομένων</string>
   <string name="waiting_for_subtitles">Αναμονή για υπότιτλους</string>
-  <string name="seeds">τροφοδότες</string>
+  <string name="seeds">%1$d τροφοδότες</string>
   <string name="start_external">Εκκίνηση εξωτερικού προγράμματος αναπαραγωγής πολυμέσων</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Μπροστά</string>

--- a/base/src/main/res/values-es-rMX/strings.xml
+++ b/base/src/main/res/values-es-rMX/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Iniciando almacenamiento</string>
   <string name="streaming_started">Transmisión iniciada</string>
   <string name="waiting_for_subtitles">Esperando los subtítulos</string>
-  <string name="seeds">fuentes</string>
+  <string name="seeds">%1$d fuentes</string>
   <string name="start_external">Iniciar reproductor externo</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Avance rápido</string>

--- a/base/src/main/res/values-es/strings.xml
+++ b/base/src/main/res/values-es/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Comenzando buffering</string>
   <string name="streaming_started">Reproducción iniciada</string>
   <string name="waiting_for_subtitles">Esperando subtítulos</string>
-  <string name="seeds">semillas</string>
+  <string name="seeds">%1$d semillas</string>
   <string name="start_external">Iniciar reproductor externo</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Avance rápido</string>

--- a/base/src/main/res/values-eu/strings.xml
+++ b/base/src/main/res/values-eu/strings.xml
@@ -198,7 +198,7 @@
   <string name="starting_buffering">Buferreratzea abiatzen</string>
   <string name="streaming_started">Jarioa hasita</string>
   <string name="waiting_for_subtitles">Azpidatziak itxaroten</string>
-  <string name="seeds">emaleak</string>
+  <string name="seeds">%1$d emaleak</string>
   <string name="start_external">Abiarazi kanpoko irakurgailua</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Azkar aurrera</string>

--- a/base/src/main/res/values-fi/strings.xml
+++ b/base/src/main/res/values-fi/strings.xml
@@ -206,7 +206,7 @@
   <string name="starting_buffering">Aloitetaan puskurointi</string>
   <string name="streaming_started">Suoratoisto aloitettu</string>
   <string name="waiting_for_subtitles">Odotetaan tekstityksiä</string>
-  <string name="seeds">jakajat</string>
+  <string name="seeds">%1$d jakajat</string>
   <string name="start_external">Käynnistä ulkoinen toistin</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Kelaa eteen</string>

--- a/base/src/main/res/values-fr/strings.xml
+++ b/base/src/main/res/values-fr/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Mise en mémoire tampon</string>
   <string name="streaming_started">La lecture a commencé</string>
   <string name="waiting_for_subtitles">En attente des sous-titres…</string>
-  <string name="seeds">Sources</string>
+  <string name="seeds">%1$d Sources</string>
   <string name="start_external">Lancer le lecteur externe</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Avance rapide</string>

--- a/base/src/main/res/values-gl/strings.xml
+++ b/base/src/main/res/values-gl/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Comezando coa carga</string>
   <string name="streaming_started">Reprodución iniciada</string>
   <string name="waiting_for_subtitles">Agardando polos subtítulos</string>
-  <string name="seeds">sementes</string>
+  <string name="seeds">%1$d sementes</string>
   <string name="start_external">Iniciar o reprodutor externo</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Avance rápido</string>

--- a/base/src/main/res/values-hr/strings.xml
+++ b/base/src/main/res/values-hr/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Pokretanje međuspremanja</string>
   <string name="streaming_started">Streamanje pokrenuto</string>
   <string name="waiting_for_subtitles">Čekanje podnaslova</string>
-  <string name="seeds">djelitelja</string>
+  <string name="seeds">%1$d djelitelja</string>
   <string name="start_external">Pokreni vanjski reproduktor</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Premotavanje unaprijed</string>

--- a/base/src/main/res/values-hu/strings.xml
+++ b/base/src/main/res/values-hu/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Pufferelés kezdése</string>
   <string name="streaming_started">Adatfolyam elkezdődött</string>
   <string name="waiting_for_subtitles">Várakozás feliratra</string>
-  <string name="seeds">seedek</string>
+  <string name="seeds">%1$d seedek</string>
   <string name="start_external">Külső lejátszó indítása</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Gyors előretekerés</string>

--- a/base/src/main/res/values-id/strings.xml
+++ b/base/src/main/res/values-id/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Mulai menyangga</string>
   <string name="streaming_started">Streaming dimulai</string>
   <string name="waiting_for_subtitles">Menunggu teks terjemahan</string>
-  <string name="seeds">seeds</string>
+  <string name="seeds">%1$d seeds</string>
   <string name="start_external">Jalankan dengan pemutar external</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Percepat</string>

--- a/base/src/main/res/values-it/strings.xml
+++ b/base/src/main/res/values-it/strings.xml
@@ -211,7 +211,7 @@
   <string name="starting_buffering">Inizio buffering</string>
   <string name="streaming_started">Streraming avviato</string>
   <string name="waiting_for_subtitles">Aspettando i sottotitoli…</string>
-  <string name="seeds">Fonti</string>
+  <string name="seeds">%1$d Fonti</string>
   <string name="start_external">Avvia lettore esterno</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Avanti veloce</string>

--- a/base/src/main/res/values-ja/strings.xml
+++ b/base/src/main/res/values-ja/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">バッファリングを開始</string>
   <string name="streaming_started">ストリーミングの開始中</string>
   <string name="waiting_for_subtitles">字幕の待機中です</string>
-  <string name="seeds">シード</string>
+  <string name="seeds">%1$d シード</string>
   <string name="start_external">外部プレイヤーを開始</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">早送り</string>

--- a/base/src/main/res/values-lt/strings.xml
+++ b/base/src/main/res/values-lt/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Pradedama buferizacija</string>
   <string name="streaming_started">Srauto perdavimas pradėtas</string>
   <string name="waiting_for_subtitles">Laukiama subtitrų</string>
-  <string name="seeds">skleidėjai</string>
+  <string name="seeds">%1$d skleidėjai</string>
   <string name="start_external">Paleisti išorinį grotuvą</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Prasukti pirmyn</string>

--- a/base/src/main/res/values-ms/strings.xml
+++ b/base/src/main/res/values-ms/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Memulakan penimbalan</string>
   <string name="streaming_started">Penstriman bermula</string>
   <string name="waiting_for_subtitles">Menunggu sarikata</string>
-  <string name="seeds">semaian</string>
+  <string name="seeds">%1$d semaian</string>
   <string name="start_external">Mulakan pemain luar</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Mundar maju</string>

--- a/base/src/main/res/values-nb/strings.xml
+++ b/base/src/main/res/values-nb/strings.xml
@@ -211,7 +211,7 @@
   <string name="starting_buffering">Starter buffering</string>
   <string name="streaming_started">Strømming startet</string>
   <string name="waiting_for_subtitles">Venter på undertekster</string>
-  <string name="seeds">Delere</string>
+  <string name="seeds">%1$d Delere</string>
   <string name="start_external">Start ekstern avspiller</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Spol fremover</string>

--- a/base/src/main/res/values-nl/strings.xml
+++ b/base/src/main/res/values-nl/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Bufferen starten…</string>
   <string name="streaming_started">Streamen gestart</string>
   <string name="waiting_for_subtitles">Wachten op ondertiteling</string>
-  <string name="seeds">seeds</string>
+  <string name="seeds">%1$d seeds</string>
   <string name="start_external">Externe speler starten</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Vooruitspoelen</string>

--- a/base/src/main/res/values-pl/strings.xml
+++ b/base/src/main/res/values-pl/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Buforowanie…</string>
   <string name="streaming_started">Rozpoczęto streamowanie</string>
   <string name="waiting_for_subtitles">Oczekiwanie na napisy</string>
-  <string name="seeds">seedów</string>
+  <string name="seeds">%1$d seedów</string>
   <string name="start_external">Zewnętrzny odtwarzacz</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Do przodu</string>

--- a/base/src/main/res/values-pt-rBR/strings.xml
+++ b/base/src/main/res/values-pt-rBR/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Iniciando armazenamento</string>
   <string name="streaming_started">Streaming iniciado</string>
   <string name="waiting_for_subtitles">Esperando por legendas</string>
-  <string name="seeds">seeds</string>
+  <string name="seeds">%1$d seeds</string>
   <string name="start_external">Iniciar o reprodutor externo</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Avançar</string>

--- a/base/src/main/res/values-pt/strings.xml
+++ b/base/src/main/res/values-pt/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">A iniciar descarga…</string>
   <string name="streaming_started">Reprodução iniciada</string>
   <string name="waiting_for_subtitles">A aguardar pelas legendas…</string>
-  <string name="seeds">sementes</string>
+  <string name="seeds">%1$d sementes</string>
   <string name="start_external">Iniciar leitor externo</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Avanço rápido</string>

--- a/base/src/main/res/values-ru/strings.xml
+++ b/base/src/main/res/values-ru/strings.xml
@@ -211,7 +211,7 @@
   <string name="starting_buffering">Буферизация началась</string>
   <string name="streaming_started">Потоковая передача началась</string>
   <string name="waiting_for_subtitles">Ожидание субтитров</string>
-  <string name="seeds">сиды</string>
+  <string name="seeds">%1$d сиды</string>
   <string name="start_external">Запускать во внешним проигрывателе</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Перемотка вперед</string>

--- a/base/src/main/res/values-sk/strings.xml
+++ b/base/src/main/res/values-sk/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Začína sa ukladanie do vyrovnávacej pamäte</string>
   <string name="streaming_started">Streamovanie začalo</string>
   <string name="waiting_for_subtitles">Čakám na titulky</string>
-  <string name="seeds">seeds</string>
+  <string name="seeds">%1$d seeds</string>
   <string name="start_external">Štart externého prehrávača</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Rýchle prevíjanie vpred</string>

--- a/base/src/main/res/values-sl/strings.xml
+++ b/base/src/main/res/values-sl/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Začetek prednalaganja</string>
   <string name="streaming_started">Začetek prenosa</string>
   <string name="waiting_for_subtitles">Čakam na podnapise</string>
-  <string name="seeds">sejalci</string>
+  <string name="seeds">%1$d sejalci</string>
   <string name="start_external">Zaženi zunanji predvajalnik</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Previj naprej</string>

--- a/base/src/main/res/values-sr/strings.xml
+++ b/base/src/main/res/values-sr/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Почетак баферовања</string>
   <string name="streaming_started">Пренос је почео</string>
   <string name="waiting_for_subtitles">Чекам титлове</string>
-  <string name="seeds">сејача</string>
+  <string name="seeds">%1$d сејача</string>
   <string name="start_external">Покрени спољни плејер</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Брзо напред</string>

--- a/base/src/main/res/values-sv/strings.xml
+++ b/base/src/main/res/values-sv/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Startar buffring</string>
   <string name="streaming_started">Streaming startad</string>
   <string name="waiting_for_subtitles">Väntar på undertexter</string>
-  <string name="seeds">seeds</string>
+  <string name="seeds">%1$d seeds</string>
   <string name="start_external">Starta extern spelare</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Snabbspola</string>

--- a/base/src/main/res/values-tr/strings.xml
+++ b/base/src/main/res/values-tr/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">Önbelleğe alma başlatılıyor</string>
   <string name="streaming_started">Yayın başladı</string>
   <string name="waiting_for_subtitles">Altyazı bekleniyor</string>
-  <string name="seeds">Göndericiler</string>
+  <string name="seeds">%1$d Göndericiler</string>
   <string name="start_external">Harici oynatıcıyı başlat</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">Hızlı ileri</string>

--- a/base/src/main/res/values-zh-rCN/strings.xml
+++ b/base/src/main/res/values-zh-rCN/strings.xml
@@ -210,7 +210,7 @@
   <string name="starting_buffering">开始缓冲</string>
   <string name="streaming_started">传输已开始</string>
   <string name="waiting_for_subtitles">等待字幕</string>
-  <string name="seeds">种子</string>
+  <string name="seeds">%1$d 种子</string>
   <string name="start_external">启用外部播放器</string>
   <!--VideoPlayerActivity strings-->
   <string name="fastforward">快进</string>

--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -270,10 +270,8 @@ By using \'Popcorn Time\' or accessing this site you affirm that you are either 
     <string name="starting_buffering">Starting buffering</string>
     <string name="streaming_started">Streaming started</string>
     <string name="waiting_for_subtitles">Waiting for subtitles</string>
-    <string name="seeds">seeds</string>
-    <string name="buffer_progress_percent">%1$d %%</string>
-    <string name="download_speed_kb">%1$s KB/s</string>
-    <string name="download_speed_mb">%1$s MB/s</string>
+    <string name="seeds">%1$d seeds</string>
+    <string name="buffer_progress_percent">%1$d%%</string>
 
     <string name="start_external">Start external player</string>
 

--- a/mobile/src/main/java/butter/droid/fragments/StreamLoadingFragment.java
+++ b/mobile/src/main/java/butter/droid/fragments/StreamLoadingFragment.java
@@ -50,6 +50,7 @@ import butter.droid.base.fragments.dialog.StringArraySelectorDialogFragment;
 import butter.droid.base.torrent.StreamInfo;
 import butter.droid.base.utils.FragmentUtil;
 import butter.droid.base.utils.PixelUtils;
+import butter.droid.base.utils.StorageUtils;
 import butter.droid.base.utils.ThreadUtils;
 import butter.droid.base.utils.VersionUtils;
 import butterknife.BindView;
@@ -156,26 +157,21 @@ public class StreamLoadingFragment extends BaseStreamLoadingFragment {
     private void updateStatus(final StreamStatus status) {
         if (FragmentUtil.isNotAdded(this)) return;
 
-        final DecimalFormat df = new DecimalFormat("#############0.00");
         ThreadUtils.runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 mProgressIndicator.setIndeterminate(false);
                 if(!mPlayingExternal) {
                     mProgressIndicator.setProgress(status.bufferProgress);
-                    mPrimaryTextView.setText(status.bufferProgress + "%");
+                    mPrimaryTextView.setText(getString(R.string.buffer_progress_percent, status.bufferProgress));
                 } else {
                     int progress = ((Float) status.progress).intValue();
                     mProgressIndicator.setProgress(progress);
-                    mPrimaryTextView.setText(progress + "%");
+                    mPrimaryTextView.setText(getString(R.string.buffer_progress_percent, progress));
                 }
 
-                if (status.downloadSpeed / 1024 < 1000) {
-                    mSecondaryTextView.setText(df.format(status.downloadSpeed / 1024) + " KB/s");
-                } else {
-                    mSecondaryTextView.setText(df.format(status.downloadSpeed / 1048576) + " MB/s");
-                }
-                mTertiaryTextView.setText(status.seeds + " " + getString(R.string.seeds));
+                mSecondaryTextView.setText(StorageUtils.formatRate((int)status.downloadSpeed));
+                mTertiaryTextView.setText(getString(R.string.seeds, status.seeds));
             }
         });
     }

--- a/tv/src/main/java/butter/droid/tv/fragments/TVStreamLoadingFragment.java
+++ b/tv/src/main/java/butter/droid/tv/fragments/TVStreamLoadingFragment.java
@@ -51,6 +51,7 @@ import java.text.DecimalFormat;
 import butter.droid.base.fragments.BaseStreamLoadingFragment;
 import butter.droid.base.providers.media.models.Show;
 import butter.droid.base.torrent.StreamInfo;
+import butter.droid.base.utils.StorageUtils;
 import butter.droid.base.utils.ThreadUtils;
 import butter.droid.tv.R;
 import butter.droid.tv.TVButterApplication;
@@ -100,7 +101,6 @@ public class TVStreamLoadingFragment extends BaseStreamLoadingFragment {
 	}
 
 	private void updateStatus(final StreamStatus status) {
-		final DecimalFormat df = new DecimalFormat("#############0.00");
 		ThreadUtils.runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
@@ -108,12 +108,8 @@ public class TVStreamLoadingFragment extends BaseStreamLoadingFragment {
 				progressIndicator.setProgress(status.bufferProgress);
                 mPrimaryTextView.setText(getString(R.string.buffer_progress_percent, status.bufferProgress));
 
-				if (status.downloadSpeed / 1024 < 1000) {
-                    mSecondaryTextView.setText(getString(R.string.download_speed_kb, df.format(status.downloadSpeed / 1024)));
-                } else {
-                    mSecondaryTextView.setText(getString(R.string.download_speed_mb, df.format(status.downloadSpeed / 1048576)));
-                }
-                mTertiaryTextView.setText(status.seeds + " " + getString(R.string.seeds));
+				mSecondaryTextView.setText(StorageUtils.formatRate((int)status.downloadSpeed));
+                mTertiaryTextView.setText(getString(R.string.seeds, status.seeds));
 			}
 		});
 	}


### PR DESCRIPTION
The symbols used for "kilo-" were incorrect, so this commit fixes
them. Also, since the SI prefixes are being used (rightly so for
any user-facing text), the bytes should be divided accordingly by
powers of 10 rather than powers of 2, since data can come in
non-powers of 2. It moves the associated strings out of the
application strings file because they are SI symbols, which are
the same in all languages, so they don't need localization.

The commit also moves the formatting for the number of seeds into
the application strings file for better localization.