### PR TITLE
Fix dependencies versions

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 
     api 'com.koushikdutta.async:androidasync:2.1.9'
 
-    api 'de.timroes:aXMLRPC:1.8.1'
+    api 'de.timroes:aXMLRPC:1.8.0'
 
     api "com.google.dagger:dagger:${rootProject.ext.daggerVersion}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.1'
         classpath 'com.jakewharton.hugo:hugo-plugin:1.2.1'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.11.1'
         classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'de.undercouch:gradle-download-task:4.0.4'

--- a/connectsdk/build.gradle
+++ b/connectsdk/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     implementation 'androidx.mediarouter:mediarouter:1.2.2'
     implementation 'com.google.android.gms:play-services-cast:20.0.0'
     implementation 'com.googlecode.plist:dd-plist:1.23'
-    implementation 'com.nimbusds:srp6a-android:2.0.2'
+    implementation 'com.nimbusds:srp6a:2.1.0'
     implementation 'net.i2p.crypto:eddsa:0.2.0'
 
     testImplementation 'org.apache.maven:maven-ant-tasks:2.1.3'

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
     implementation 'de.hdodenhof:circleimageview:2.0.0'
-    implementation 'com.github.nirhart:parallaxscroll:dd53d1f9d1'
+    implementation 'com.github.nirhart:parallaxscroll:1.0'
     implementation 'com.larswerkman:HoloColorPicker:1.5'
     implementation 'com.github.guardian:Option:-SNAPSHOT' 
     implementation 'net.rdrei.android.dirchooser:library:3.0@aar'


### PR DESCRIPTION
Hello, some dependencies are now deprecated and not available in the repositories. This PR the following dependencies to the next available versions that can build both the mobile and TV versions of the application:

```
- de.timroes:aXMLRPC:1.8.0 -> de.timroes:aXMLRPC:1.8.1
- com.github.ben-manes:gradle-versions-plugin:0.17.0 -> com.github.ben-manes:gradle-versions-plugin:0.11.1 # the 0.17.0 is not anymore available
- com.nimbusds:srp6a-android:2.0.2 -> com.nimbusds:srp6a:2.1.0 # the srp6a-android project is deprecated and no builds are available. srp6a seems to provide the same interfaces
- com.github.nirhart:parallaxscroll:dd53d1f9d1 -> com.github.nirhart:parallaxscroll:1.0
```

Builds can now succeed and I've done some basic manual testing of them on AndroidTV and Android.